### PR TITLE
Fix invalid license in META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -41,7 +41,7 @@
   "resources": [
     "spec_file.crotmp"
   ],
-  "license": "Apache License 2.0",
+  "license": "Apache-2.0",
   "tags": [],
   "source-url": "https://github.com/wbiker/module2rpm"
 }


### PR DESCRIPTION
The license field should be a valid SPDX identifier as mentioned under https://docs.raku.org/language/modules#Preparing_the_module