### PR TITLE
Fix build on Fedora

### DIFF
--- a/resources/spec_file.crotmp
+++ b/resources/spec_file.crotmp
@@ -32,6 +32,7 @@ BuildRequires:  fdupes
 <&HTML-AND-JAVASCRIPT($_)>
 </@>
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
+%global debug_package %{nil}
 %description
 <.summary>
 %prep


### PR DESCRIPTION
Fixes "error: Empty %files file /home/abuild/rpmbuild/BUILD/.../debugfiles.list"
on Fedora (and other Redhat based distros)